### PR TITLE
link application instruction to relevant wiki pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,8 +114,8 @@
                         <li>了解社区礼仪并严格要求自己</li>
                         <li>能够做到对社区、对自己负责</li>
                         <li>拥有合法的 Mojang 正版帐号</li>
-                        <li>得到喵窝玩家的邀请</li>
-                        <li>已经认真阅读喵窝服务器游戏规则</li>
+                        <li>得到喵窝玩家的邀请（<a href="https://wiki.nyaa.cat/%E7%8E%A9%E5%AE%B6%E7%A9%BA%E9%97%B4:%E5%A6%82%E4%BD%95%E8%8E%B7%E5%BE%97%E9%82%80%E8%AF%B7">如何获得？</a>）</li>
+                        <li>已经认真阅读<a href="https://wiki.nyaa.cat/%E6%B8%B8%E6%88%8F%E8%A7%84%E5%88%99">喵窝服务器游戏规则</a></li>
                     </ul>
                 </div>
                 <div class="right">
@@ -131,6 +131,7 @@
                                     <li>个人主页地址</li>
                                     <li>简单的自我介绍</li>
                                     <li>申请起源，包括：从何处得知喵窝、为何选择喵窝、以前的单机/联机游戏经历及感受等</li>
+                                    <li>（请参考<a href="https://wiki.nyaa.cat/%E6%96%B0%E7%8E%A9%E5%AE%B6%E7%94%B3%E8%AF%B7">申请信具体要求和审核标准</a>。）</li>
                                 </ol>
                             </li>
                         </ul>


### PR DESCRIPTION
This PR adds some links to the NyaaCat wiki pages to provide more information about the application process. Editing of the application requirements can then be easily and collaboratively done on the wiki.

This also encourages everybody to actually read the game and community rules on the wiki before smashing on the email SEND button.